### PR TITLE
fix: Add OPTIONS handler to /api/room route

### DIFF
--- a/app/api/room/route.ts
+++ b/app/api/room/route.ts
@@ -83,4 +83,16 @@ export async function GET(req: NextRequest) {
     console.error('Unexpected error fetching room:', e);
     return NextResponse.json({ error: 'Unexpected error fetching room', details: e.message }, { status: 500 });
   }
+}
+
+// Explicitly handle OPTIONS requests
+export async function OPTIONS(req: NextRequest) {
+  return NextResponse.json(null, {
+    status: 204, // No Content
+    headers: {
+      'Access-Control-Allow-Origin': '*', // Adjust as necessary for your CORS policy
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
 } 


### PR DESCRIPTION
This change introduces an explicit OPTIONS request handler for the /api/room endpoint.

The purpose is to potentially resolve a 405 "Method Not Allowed" error that was occurring for POST requests in the deployed environment. Explicitly defining an OPTIONS handler can sometimes help with CORS preflight requests or method negotiation on certain deployment platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP OPTIONS requests to the room API, improving compatibility with cross-origin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->